### PR TITLE
Fix editing view when clicking Create

### DIFF
--- a/app/routes/posts.js
+++ b/app/routes/posts.js
@@ -18,7 +18,7 @@ export default Ember.Route.extend({
   
   actions: {
     createPost: function() {
-      this.controllerFor('post').send('edit');
+      this.controllerFor('post').set('isEditing', true);
       var newPost = this.get('store').createRecord('post');
       newPost.set('date' , new Date());
       newPost.set('author' , 'C.L.I. Ember');


### PR DESCRIPTION
I entered the root path and immediatly clicked the Create-button, but the editing view was not toggled. It complained about the 'edit' route. What was intended in routes/post.js is instead (also) done in routes/posts.js with this patch. Now it works! I don't know if it's the best way but I guess it is a way. :-) Have a great day, and thanks for the example code!
