### PR TITLE
update ember-pouch and pouchdb

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -3,15 +3,7 @@ import config from '../config/environment';
 var db = new PouchDB(config.local_couch || 'bloggr');
 var remote = new PouchDB(config.remote_couch, {ajax: {timeout: 20000}});
 
-function doSync() {
-  db.sync(remote, {live: true})
-    .on('error', function() {
-      // Retry connection every 5 seconds
-      setTimeout(doSync, 5000);
-    });
-}
-
-doSync();
+db.sync(remote, {live: true, retry: true});
 
 export default EmberPouch.Adapter.extend({
   db: db

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "ember-qunit": "0.2.8",
     "ember-qunit-notifications": "0.0.7",
     "qunit": "~1.17.1",
-    "ember-pouch": "~1.1.6",
+    "ember-pouch": "^1.1.6",
     "moment": "~2.9.0",
     "marked": "~0.3.2",
     "bootstrap": "~3.2.0"


### PR DESCRIPTION
You don't need to manage syncing yourself anymore. We now have `retry` in PouchDB 3.3.1.

Also, this was using an older version of ember-pouch that wasn't handling updates/deletions automatically.