### PR TITLE
tabs to spaces

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -17,34 +17,34 @@ export default Adapter.extend({
 
     let localDb = config.local_couch || 'blogger';
 
-	  assert('local_couch must be set', !isEmpty(localDb));
+    assert('local_couch must be set', !isEmpty(localDb));
 
-	  let db = new PouchDB(localDb);
-  	let self = this;
+    let db = new PouchDB(localDb);
+    let self = this;
 
     let remoteDb = new PouchDB(config.remote_couch, {ajax: {timeout: 20000}});
 
     let replicationOptions = {
-	    live: true,
-	    retry: true
-  	};
+      live: true,
+      retry: true
+    };
 
-	  db.replicate.from(remoteDb, replicationOptions).on('paused', function (err) {
+    db.replicate.from(remoteDb, replicationOptions).on('paused', function (err) {
       self.get('cloudState').setPull(!err);
     });
 
-	  db.replicate.to(remoteDb, replicationOptions).on('denied', (err) => {
-		  if (!err.id.startsWith('_design/')) {
-			  //there was an error pushing, probably logged out outside of this app (couch/cloudant dashboard)
-			  self.get('session').invalidate();//this cancels the replication
+    db.replicate.to(remoteDb, replicationOptions).on('denied', (err) => {
+      if (!err.id.startsWith('_design/')) {
+        //there was an error pushing, probably logged out outside of this app (couch/cloudant dashboard)
+        self.get('session').invalidate();//this cancels the replication
 
-		    throw({message: "Replication failed. Check login?"});//prevent doc from being marked replicated
-		  }
- 	  }).on('paused',(err) => {
+        throw({message: "Replication failed. Check login?"});//prevent doc from being marked replicated
+      }
+    }).on('paused',(err) => {
       self.get('cloudState').setPush(!err);
     }).on('error',() => {
-   		self.get('session').invalidate();//mark error by loggin out
- 	  });
+      self.get('session').invalidate();//mark error by loggin out
+    });
 
     this.set('remoteDb', remoteDb);
     this.set('db', db);

--- a/app/authenticators/pouch.js
+++ b/app/authenticators/pouch.js
@@ -1,9 +1,9 @@
 import Pouch from 'ember-simple-auth-pouch/authenticators/pouch';
 
 export default Pouch.extend({
-	getDb() {
-	    let pouchAdapter = this.get('store').adapterFor('application');//getOwner(this).lookup(`adapter:${pouchAdapterName}`);
+  getDb() {
+      let pouchAdapter = this.get('store').adapterFor('application');//getOwner(this).lookup(`adapter:${pouchAdapterName}`);
 
-		return pouchAdapter.remoteDb;
-	}
+    return pouchAdapter.remoteDb;
+  }
 });

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -3,12 +3,12 @@ import Ember from "ember";
 const { get, inject: {service} } = Ember;
 
 export default Ember.Controller.extend({
-	session: service(),
+  session: service(),
   cloudState: service(),
 
-	actions:{
+  actions:{
     logout: function() {
-    	get(this, 'session').invalidate();
+      get(this, 'session').invalidate();
     }
   }
 });

--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -7,7 +7,7 @@ export default Ember.Controller.extend({
     authenticate() {
       let { identification, password } = this.getProperties('identification', 'password');
       this.get('session').authenticate('authenticator:pouch', identification, password).then(() => {
-      	this.setProperties({identification: '', password: ''});
+        this.setProperties({identification: '', password: ''});
       }).catch((reason) => {
         this.set('errorMessage', reason.message || reason);
       });

--- a/app/helpers/format-date.js
+++ b/app/helpers/format-date.js
@@ -2,6 +2,6 @@ import Ember from "ember";
 import moment from 'moment';
 
 export default Ember.Helper.helper(function(params) {
-	let value = params[0];
+  let value = params[0];
   return moment(value).fromNow();
 });

--- a/app/models/author.js
+++ b/app/models/author.js
@@ -2,7 +2,7 @@ import DS from "ember-data";
 import { Model } from 'ember-pouch';
 
 var Author = Model.extend({
-	name: DS.attr('string', {defaultValue: ""}),
+  name: DS.attr('string', {defaultValue: ""}),
   posts: DS.hasMany('posts')
 });
 

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -2,11 +2,11 @@ import DS from "ember-data";
 import { Model } from 'ember-pouch';
 
 var Post = Model.extend({
-	title: DS.attr('string', {defaultValue: ""}),
-	author: DS.belongsTo('author'),
-	date: DS.attr('date'),
-	excerpt: DS.attr('string', {defaultValue: ""}),
-	body: DS.attr('string', {defaultValue: ""})
+  title: DS.attr('string', {defaultValue: ""}),
+  author: DS.belongsTo('author'),
+  date: DS.attr('date'),
+  excerpt: DS.attr('string', {defaultValue: ""}),
+  body: DS.attr('string', {defaultValue: ""})
 });
 
 export default Post;

--- a/app/router.js
+++ b/app/router.js
@@ -7,15 +7,15 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-	this.route('about');
-	this.route('secret');
-	this.route('login');
-	this.route('posts', function() {
-		this.route('post', { path: ':post_id', resetNamespace: true });
-	});
-	this.route('authors', function() {
-		this.route('author', { path: ':author_id', resetNamespace: true });
-	});
+  this.route('about');
+  this.route('secret');
+  this.route('login');
+  this.route('posts', function() {
+    this.route('post', { path: ':post_id', resetNamespace: true });
+  });
+  this.route('authors', function() {
+    this.route('author', { path: ':author_id', resetNamespace: true });
+  });
 });
 
 export default Router;

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -2,9 +2,9 @@ import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mi
 import Ember from "ember";
 
 export default Ember.Route.extend(ApplicationRouteMixin, {
-	sessionInvalidated() {
-		//data may still be viewed, so no window.reload needed
-		//remove sessionInvalidated and go back to default ApplicationRouteMixin behaviour if you want to clear JS cache after logout
-		this.transitionTo('index');
-	},
+  sessionInvalidated() {
+    //data may still be viewed, so no window.reload needed
+    //remove sessionInvalidated and go back to default ApplicationRouteMixin behaviour if you want to clear JS cache after logout
+    this.transitionTo('index');
+  },
 });

--- a/app/routes/author.js
+++ b/app/routes/author.js
@@ -1,7 +1,7 @@
 import Ember from "ember";
 
 export default Ember.Route.extend({
-	model: function(params) {
-		return this.store.findRecord('author', params.author_id);
-	}
+  model: function(params) {
+    return this.store.findRecord('author', params.author_id);
+  }
 });

--- a/app/routes/authors.js
+++ b/app/routes/authors.js
@@ -14,17 +14,17 @@ export default Ember.Route.extend({
   },
 
   actions: {
-		createAuthor: function() {
+    createAuthor: function() {
       this.controllerFor('author').set('globals.isEditing', true);
       var newauthor = this.store.createRecord('author');
       this.transitionTo('author', newauthor.save());
     },
 
-		saveAuthor: function() {
-			this.modelFor('author').save();
-		},
+    saveAuthor: function() {
+      this.modelFor('author').save();
+    },
 
-		deleteAuthor: function() {
+    deleteAuthor: function() {
       this.modelFor('author').destroyRecord().then(function() {
         this.transitionTo('authors');
       }.bind(this));

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,6 +1,6 @@
 import Ember from "ember";
 export default Ember.Route.extend({
-	beforeModel: function() {
-		this.transitionTo('posts');
-	}
+  beforeModel: function() {
+    this.transitionTo('posts');
+  }
 });

--- a/app/routes/post.js
+++ b/app/routes/post.js
@@ -1,7 +1,7 @@
 import Ember from "ember";
 
 export default Ember.Route.extend({
-	model: function(params) {
-		return this.store.findRecord('post', params.post_id);
-	}
+  model: function(params) {
+    return this.store.findRecord('post', params.post_id);
+  }
 });

--- a/app/routes/secret.js
+++ b/app/routes/secret.js
@@ -2,5 +2,5 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 import Ember from "ember";
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
-	// do your secret model setup here
+  // do your secret model setup here
 });


### PR DESCRIPTION
2 spaces is what is set within `.editorconfig` however there are instances where tabs were used, this fixes it

accomplished by:

```
find . -name '*.js' ! -type d -exec bash -c 'expand -t 2 "$0" > /tmp/e && mv /tmp/e "$0"' {} \;
```