### PR TITLE
Workaround weird bug that only happens when you have focus on search …

### DIFF
--- a/app/controllers/posts.js
+++ b/app/controllers/posts.js
@@ -3,6 +3,7 @@ import Ember from "ember";
 export default Ember.Controller.extend({
   page: 1,
   perPage: 5,
+  query: '',
 
   queryParams: ["page", "perPage", "query"]
 });


### PR DESCRIPTION
Workaround weird bug that only happens when you have focus on search box and no ?query= in the url and then click on a page link. Seems to update query and ignore the page click (maybe because component is rerendered?)

Can't seem to build a repro for this on twiddle, this is my initial try, but it seems to work as it should
https://ember-twiddle.com/e2ae34408684b970278bd5c05df1c18c?openFiles=controllers.application.js%2C&route=%2F%3Fclicked%3Dtrue%26query%3D