### PR TITLE
Let posts be loaded async from model

### DIFF
--- a/app/routes/authors.js
+++ b/app/routes/authors.js
@@ -3,15 +3,7 @@ import { hash } from 'rsvp';
 
 export default Route.extend({
   model: function() {
-    var store = this.store;
-    return hash({
-      model: store.findAll('author'),
-      posts: store.findAll('post')
-    });
-  },
-
-  setupController: function(controller, models) {
-    controller.setProperties(models);
+    return this.store.findAll('author');
   },
 
   actions: {


### PR DESCRIPTION
This should be the only thing needed to load the posts async. The serializer that is required is now automatically included by ember-pouch in the app directory.

I should add that this is not fully tested, as I only made the change on github ;-)