### PR TITLE
Overridden components migrated to octane

### DIFF
--- a/app/components/blog-post-edit.hbs
+++ b/app/components/blog-post-edit.hbs
@@ -5,7 +5,7 @@
   <p><Input @type="text" @value={{@post.excerpt}} class="form-control" placeholder="Post exercept" /></p>
   <p><MarkdownEditor @value={{@post.body}} @placeholder="Post content" @rows="5" /></p>
 
-  <p><button type="button" class="btn btn-danger" {{on "click" @deletePost}} class="btn btn-default">Delete</button></p>
+  <p><button type="button" class="btn btn-danger" {{on "click" @deletePost}}>Delete</button></p>
 {{else}}
   <p><button type="button" class="btn btn-secondary" {{on "click" this.edit}}>Edit</button></p>
 {{/if}}

--- a/app/components/markdown-editor.hbs
+++ b/app/components/markdown-editor.hbs
@@ -13,7 +13,7 @@
           </button>
         {{/if}}
         {{#if btn.helpType}}
-          <a class="btn btn-light" title={{t btn.tooltip}} href="{{t btn.href}}" target="_blank" tabindex="-1">
+          <a class="btn btn-light" title={{t btn.tooltip}} href="{{t btn.href}}" target="_blank" rel="noopener noreferrer" tabindex="-1">
             {{svg-jar btn.iconSvg size="1" class="markdown-button" fill="#337ab7"}}
           </a>
         {{/if}}
@@ -39,7 +39,7 @@
     readonly={{this.readonly}}
     required={{this.required}}
     rows={{this.rows}}
-    tabindex={{this.modalTabindex}}
+    tabindex={{if this.modal -1 this.modalTabindex}}
     wrap={{this.wrap}} />
 </div>
 
@@ -47,36 +47,36 @@
   <div class="modal d-block" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">
       <div class="modal-content">
-        {{#if dialog}}
+        {{#if this.dialog}}
           <div class="modal-header">
-            <h5 class="modal-title" id="gridSystemModalLabel">{{t tooltip}}</h5>
+            <h5 class="modal-title" id="gridSystemModalLabel">{{t this.tooltip}}</h5>
             <button type="button" class="close" data-dismiss="modal" aria-label="Close" {{on "click" this.cancel}}>
               <span aria-hidden="true">&times;</span>
             </button>
           </div>
           <div class="modal-body">
-            <p>{{t 'markdown-editor.modal.selectionText'}}</p>
+            <p>{{t "markdown-editor.modal.selectionText"}}</p>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-primary" data-dismiss="modal" {{on "click" this.cancel}}>
-              <span>{{svg-jar "check" size="1" fill="white" class="markdown-button"}}</span> &nbsp;{{t 'markdown-editor.modal.confirm'}}</button>
+              <span>{{svg-jar "check" size="1" fill="white" class="markdown-button"}}</span> &nbsp;{{t "markdown-editor.modal.confirm"}}</button>
           </div>
         {{else}}
           <div class="modal-header">         
-            <h5 class="modal-title" id="gridSystemModalLabel">{{t tooltip}}</h5>
+            <h5 class="modal-title" id="gridSystemModalLabel">{{t this.tooltip}}</h5>
             <button type="button" class="close" data-dismiss="modal" aria-label="Close" {{on "click" this.cancel}}>
               <span aria-hidden="true">&times;</span>
             </button>
           </div>
           <div class="modal-body">
-            <p>{{input type="text" value=this.result class="form-control" placeholder=(t promptText)}}</p>
+            <p><Input type="text" @value={{this.result}} class="form-control" placeholder={{t this.promptText}} /></p>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-primary" {{on "click" (fn this.confirm this.result)}}>
-              <span>{{svg-jar "check" size="1" fill="white" class="markdown-button"}}</span> &nbsp;{{t 'markdown-editor.modal.confirm'}}
+              <span>{{svg-jar "check" size="1" fill="white" class="markdown-button"}}</span> &nbsp;{{t "markdown-editor.modal.confirm"}}
             </button>
             <button type="button" class="btn btn-secondary" data-dismiss="modal" {{on "click" this.cancel}}>
-              <span>{{svg-jar "close" size="1" class="markdown-button" fill="#ffffff"}}</span> &nbsp;{{t 'markdown-editor.modal.cancel'}}
+              <span>{{svg-jar "close" size="1" class="markdown-button" fill="#ffffff"}}</span> &nbsp;{{t "markdown-editor.modal.cancel"}}
             </button>
           </div>
         {{/if}}

--- a/app/components/markdown-editor.hbs
+++ b/app/components/markdown-editor.hbs
@@ -1,14 +1,14 @@
 <div class="markdown-editor-toolbar">
-  {{#each toolbarBtns as |btnGroup|}}
+  {{#each this.toolbarBtns as |btnGroup|}}
     <div class="btn-group">
       {{#each btnGroup as |btn|}}
         {{#if btn.defaultType}}
-          <button type="button" class="btn btn-light" {{action "applyStyle" btn.regex btn.requireSelection btn.prompt btn.tooltip btn.enter}} title={{t btn.tooltip}} tabindex="-1">
+          <button type="button" class="btn btn-light" {{on "click" (fn this.applyStyle btn.regex btn.requireSelection btn.prompt btn.tooltip btn.enter)}} title={{t btn.tooltip}} tabindex="-1">
             {{svg-jar btn.iconSvg size="1" class="markdown-button"}}
           </button>
         {{/if}}
         {{#if btn.undoType}}
-          <button type="button" class="btn btn-light" {{action 'undo'}} title={{t btn.tooltip}} disabled={{noUndo}} tabindex="-1">
+          <button type="button" class="btn btn-light" {{on "click" this.undo}} title={{t btn.tooltip}} disabled={{this.noUndo}} tabindex="-1">
             {{svg-jar btn.iconSvg size="1" class="markdown-button"}}
           </button>
         {{/if}}
@@ -23,35 +23,35 @@
 </div>
 
 <div class="markdown-editor-editor">
-  {{textarea
-    focus-out=(action 'handleTextareaBlur')
-    id=textareaId
-    class='markdown-editor-textarea form-control'
-    value=value
-    autofocus=autofocus
-    cols=cols
-    dirname=dirname
-    disabled=disabled
-    form=form
-    maxlength=maxlength
-    name=name
-    placeholder=placeholder
-    readonly=readonly
-    required=required
-    rows=rows
-    tabindex=modalTabindex
-    wrap=wrap
-  }}
+  <Textarea
+    @focus-out={{fn this.handleTextareaBlur}}
+    id={{this.textareaId}}
+    class="markdown-editor-textarea form-control"
+    @value={{this.value}}
+    autofocus={{this.autofocus}}
+    cols={{this.cols}}
+    dirname={{this.dirname}}
+    disabled={{this.disabled}}
+    form={{this.form}}
+    maxlength={{this.maxlength}}
+    name={{this.name}}
+    placeholder={{this.placeholder}}
+    readonly={{this.readonly}}
+    required={{this.required}}
+    rows={{this.rows}}
+    tabindex={{this.modalTabindex}}
+    wrap={{this.wrap}}
+  ></Textarea>
 </div>
 
-{{#if modal}}
+{{#if this.modal}}
   <div class="modal d-block" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         {{#if dialog}}
           <div class="modal-header">
             <h5 class="modal-title" id="gridSystemModalLabel">{{t tooltip}}</h5>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close" {{action 'cancel'}}>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close" {{on "click" this.cancel}}>
               <span aria-hidden="true">&times;</span>
             </button>
           </div>
@@ -59,24 +59,24 @@
             <p>{{t 'markdown-editor.modal.selectionText'}}</p>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-primary" data-dismiss="modal" {{action 'cancel'}}>
+            <button type="button" class="btn btn-primary" data-dismiss="modal" {{on "click" this.cancel}}>
               <span>{{svg-jar "check" size="1" fill="white" class="markdown-button"}}</span> &nbsp;{{t 'markdown-editor.modal.confirm'}}</button>
           </div>
         {{else}}
           <div class="modal-header">         
             <h5 class="modal-title" id="gridSystemModalLabel">{{t tooltip}}</h5>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close" {{action 'cancel'}}>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close" {{on "click" this.cancel}}>
               <span aria-hidden="true">&times;</span>
             </button>
           </div>
           <div class="modal-body">
-            <p>{{input type="text" value=result class="form-control" placeholder=(t promptText)}}</p>
+            <p>{{input type="text" value=this.result class="form-control" placeholder=(t promptText)}}</p>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-primary" {{action 'confirm' result}}>
+            <button type="button" class="btn btn-primary" {{on "click" (fn this.confirm this.result)}}>
               <span>{{svg-jar "check" size="1" fill="white" class="markdown-button"}}</span> &nbsp;{{t 'markdown-editor.modal.confirm'}}
             </button>
-            <button type="button" class="btn btn-secondary" data-dismiss="modal" {{action 'cancel'}}>
+            <button type="button" class="btn btn-secondary" data-dismiss="modal" {{on "click" this.cancel}}>
               <span>{{svg-jar "close" size="1" class="markdown-button" fill="#ffffff"}}</span> &nbsp;{{t 'markdown-editor.modal.cancel'}}
             </button>
           </div>

--- a/app/components/markdown-editor.hbs
+++ b/app/components/markdown-editor.hbs
@@ -40,8 +40,7 @@
     required={{this.required}}
     rows={{this.rows}}
     tabindex={{this.modalTabindex}}
-    wrap={{this.wrap}}
-  ></Textarea>
+    wrap={{this.wrap}} />
 </div>
 
 {{#if this.modal}}

--- a/app/components/markdown-editor.js
+++ b/app/components/markdown-editor.js
@@ -1,5 +1,76 @@
 import MarkdownEditor from 'ember-cli-markdown-editor/components/markdown-editor';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
 export default class MarkdownEditorComponent extends MarkdownEditor  {
+ 
+  @action handleTextareaBlur(){
+    var that = this,
+      textComponent = document.getElementById(that.get('textareaId')),
+      selection, startPos, endPos,
+      lastchar = '\n';
 
+    startPos = textComponent.selectionStart;
+    endPos = textComponent.selectionEnd;
+    selection = textComponent.value.substring(startPos, endPos);
+
+    if (startPos) {
+      lastchar = textComponent.value.substring(startPos - 1, startPos);
+    }
+
+    that.setProperties({
+      startPos: startPos,
+      endPos: endPos,
+      selection: selection,
+      lastchar: lastchar
+    });
+  }
+ 
+  @action applyStyle(regex, requireSelection = false, promptText = null, tooltip = null ,enter){
+    this.set('regex', regex);
+    this.set('enter', enter);
+    this.set('promptText', promptText);
+    this.set('tooltip', tooltip);
+
+    if(!this.get('selection') && requireSelection){
+      this.set('modal', true);
+      this.set('dialog', true);
+    } else if (promptText){
+      this.set('modal', true);
+      this.set('dialog', false);
+    } else {
+      this.set('modal', false);
+      this.send('setValue', regex, enter);
+    }
+  }
+
+  @action confirm(result) {
+    let that = this,
+      regex = that.get('regex'),
+      enter = that.get('enter');
+      regex = regex.replace('{{result}}', result);
+    this.send('setValue', regex, enter);
+    this.set('modal', '');
+  }
+
+  @action cancel() {
+    this.set('modal', '');
+  }
+
+  @action undo() {
+    var that = this,
+      undoHistory = that.get('undoHistory').toArray();
+
+    if(undoHistory.length === 0){
+      alert('No more steps to undo.');
+      return false;
+    }
+
+    var restoreValue = undoHistory.pop();
+
+    that.setProperties({
+      undoHistory: Ember.A(undoHistory),
+      value: restoreValue
+    });
+  }
 }

--- a/app/components/markdown-editor.js
+++ b/app/components/markdown-editor.js
@@ -1,6 +1,6 @@
 import MarkdownEditor from 'ember-cli-markdown-editor/components/markdown-editor';
-import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { A } from '@ember/array';
 
 export default class MarkdownEditorComponent extends MarkdownEditor  {
  
@@ -32,7 +32,7 @@ export default class MarkdownEditorComponent extends MarkdownEditor  {
     this.set('promptText', promptText);
     this.set('tooltip', tooltip);
 
-    if(!this.get('selection') && requireSelection){
+    if(!this.selection && requireSelection){
       this.set('modal', true);
       this.set('dialog', true);
     } else if (promptText){
@@ -69,7 +69,7 @@ export default class MarkdownEditorComponent extends MarkdownEditor  {
     var restoreValue = undoHistory.pop();
 
     that.setProperties({
-      undoHistory: Ember.A(undoHistory),
+      undoHistory: A(undoHistory),
       value: restoreValue
     });
   }

--- a/app/components/page-numbers.hbs
+++ b/app/components/page-numbers.hbs
@@ -18,7 +18,7 @@
       {{/if}}
       {{#if item.current}}
         <li class="page-item active page-number">
-          <a class="page-link">{{item.page}}</a>
+          <a href="#" class="page-link">{{item.page}}</a>
         </li>
       {{else}}
         <li class="page-item page-number">

--- a/app/components/page-numbers.hbs
+++ b/app/components/page-numbers.hbs
@@ -1,16 +1,16 @@
 <div class="pagination-centered">
   <ul class="pagination">
-    {{#if canStepBackward}}
+    {{#if this.canStepBackward}}
       <li class="page-item arrow prev enabled-arrow">
-        <a href="#" {{action "incrementPage" -1}} class="page-link">&laquo;</a>
+        <a href="#" {{on "click" (fn this.incrementPage -1)}} class="page-link">&laquo;</a>
       </li>
     {{else}}
       <li class="page-item arrow prev disabled">
-        <a href="#" {{action "incrementPage" -1}} class="page-link">&laquo;</a>
+        <a href="#" {{on "click" (fn this.incrementPage -1)}} class="page-link">&laquo;</a>
       </li>
     {{/if}}
 
-    {{#each pageItems as |item|}}
+    {{#each this.pageItems as |item|}}
       {{#if item.dots}}
         <li class="page-item dots disabled">
           <span>...</span>
@@ -22,18 +22,18 @@
         </li>
       {{else}}
         <li class="page-item page-number">
-          <a href="#" {{action "pageClicked" item.page}} class="page-link">{{item.page}}</a>
+          <a href="#" {{on "click" (fn this.pageClicked item.page)}} class="page-link">{{item.page}}</a>
         </li>
       {{/if}}
     {{/each}}
 
-    {{#if canStepForward}}
+    {{#if this.canStepForward}}
       <li class="page-item arrow next enabled-arrow">
-        <a href="#" {{action "incrementPage" 1}}class="page-link">&raquo;</a>
+        <a href="#" {{on "click" (fn this.incrementPage 1)}} class="page-link">&raquo;</a>
       </li>
     {{else}}
       <li class="page-item arrow next disabled">
-        <a href="#" {{action "incrementPage" 1}} class="page-link">&raquo;</a>
+        <a href="#" {{on "click" (fn this.incrementPage 1)}} class="page-link">&raquo;</a>
       </li>
     {{/if}}
   </ul>

--- a/app/components/page-numbers.js
+++ b/app/components/page-numbers.js
@@ -1,5 +1,4 @@
 import PageNumbers from 'ember-cli-pagination/components/page-numbers';
-import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import Util from 'ember-cli-pagination/util';
 
@@ -12,14 +11,14 @@ export default class PageNumbersComponent extends PageNumbers  {
   }
   
   @action incrementPage(num) {
-    const currentPage = Number(this.get("currentPage")),
-         totalPages = Number(this.get("totalPages"));
+    const currentPage = Number(this.currentPage),
+         totalPages = Number(this.totalPages);
 
     if(currentPage === totalPages && num === 1) { return false; }
     if(currentPage <= 1 && num === -1) { return false; }
     this.incrementProperty('currentPage', num);
 
-    const newPage = this.get('currentPage');
+    const newPage = this.currentPage;
     this._runAction('action', newPage);
   }
 

--- a/app/components/page-numbers.js
+++ b/app/components/page-numbers.js
@@ -1,5 +1,26 @@
 import PageNumbers from 'ember-cli-pagination/components/page-numbers';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import Util from 'ember-cli-pagination/util';
 
 export default class PageNumbersComponent extends PageNumbers  {
+
+  @action pageClicked(number) {
+    Util.log("PageNumbers#pageClicked number " + number);
+    this.set("currentPage", number);
+    this._runAction('action', number);
+  }
+  
+  @action incrementPage(num) {
+    const currentPage = Number(this.get("currentPage")),
+         totalPages = Number(this.get("totalPages"));
+
+    if(currentPage === totalPages && num === 1) { return false; }
+    if(currentPage <= 1 && num === -1) { return false; }
+    this.incrementProperty('currentPage', num);
+
+    const newPage = this.get('currentPage');
+    this._runAction('action', newPage);
+  }
 
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21132,8 +21132,8 @@
       "integrity": "sha512-K1bPl1X3eermPcZMThzRXHmGCfk1+GGceHhLar5b3NPZy55DKlUsuQOjsWKQ0vHG/c5aR3G40i3Drt1DdnIoSA==",
       "dev": true,
       "requires": {
-        "@ember/edition-utils": "^1.1.1",
-        "babel-plugin-htmlbars-inline-precompile": "^3.0.0",
+        "@ember/edition-utils": "^1.2.0",
+        "babel-plugin-htmlbars-inline-precompile": "^3.0.1",
         "broccoli-debug": "^0.6.5",
         "broccoli-persistent-filter": "^2.3.1",
         "broccoli-plugin": "^4.0.3",


### PR DESCRIPTION
Overridden components from addon ember-cli-markdown-editor and ember-cli-pagination migrated to octane.
Some actions needed to be overridden to be able use octane syntax on their templates.